### PR TITLE
RFC: Unicode strings and characters

### DIFF
--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -55,10 +55,10 @@ This change in definition can cause previously verified code to no longer verify
 since expressions such as `someIntValue as char` or `someCharValue + 'a'` are no longer allowed to result in
 surrogate code points.
 
-Using `/unicodeChar:1` will also cause the parser to reject `/uXXXX` UTF-16 code unit escape sequences,
+Using `/unicodeChar:1` will also cause the parser to reject `\uXXXX` UTF-16 code unit escape sequences,
 such as the `"\uD800"` value above.
 A new `\U{XXXXXX}` escape sequence is available to encode Unicode scalar values directly instead,
-accepting between one and dix hexadecimal digits.
+accepting between one and six hexadecimal digits.
 This ensures Dafny string literals can always be represented in UTF-8, UTF-16, or any other Unicode encoding.
 This new escape sequence can always be used, independently of the `/unicodeChar` switch value,
 and hence can be used to aid in migrating from the old semantics to the new semantics.
@@ -94,7 +94,7 @@ method Main() {
 }
 ```
 
-Note that a related but largely orthogonal issue [has been fixed
+Note that a related but largely orthogonal issue has been fixed
 (although not yet released at the time of writing this).
 Dafny source code files must be encoded in UTF-8, but in previous versions of Dafny,
 string and character literals could only contain printable and white-space ASCII characters,
@@ -182,7 +182,7 @@ currently take constant time on an `StringDafnySequence`, since a `java.lang.Str
 code units. However, if `UnicodeStringDafnySequence.select(i)` will need to produce the i'th Unicode scalar value instead,
 this will require decoding all characters up to that index, which will take linear time in general instead.
 
-There are at two three possible approaches a given backend can take:
+There are at least two possible approaches a given backend can take:
 
 1. Cache the most recently calculated index into the string value.
    On the next indexing operation, decode forwards or backwards from this position
@@ -330,7 +330,7 @@ to the core definition of Dafny, and a much higher likelihood of having to chang
 the language definition or implementation to support future versions of Unicode.
 It would also mean `char` can no longer be represented as a single integer value,
 instead needing multiple scalar values in some cases,
-which would be a large a deep change to the encoding of `char` in the Boogie prelude and translator.
+which would be a large and deep change to the encoding of `char` in the Boogie prelude and translator.
 
 # Prior art
 [prior-art]: #prior-art
@@ -356,7 +356,7 @@ encoding its data either in UTF-16 or in Latin-1, where the latter is an optimiz
 when all characters in the string are supported by this encoding.
 A `String` value may contain invalid sequences such as unpaired surrogates.
 
-Java does not included a dedicated type for Unicode scalar values
+Java does not include a dedicated type for Unicode scalar values
 and instead uses the 32-bit wide `int` primitive type.
 The `CharSequence.codePoints()` method produces an `IntStream` enumerating the UTF-32 code points in a valid String,
 but will enumerate unpaired surrogates directly as zero-extended `int` values.

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -170,11 +170,11 @@ The cheapest solution to implement would likely be to add a new requirement in t
 that surrogate `char` values are only used in pairs as intended.
 This would likely require more user effort to migrate their code, however,
 as every operation on strings would now have to prove that a surrogate pair
-is not being split up.
+is not being split up. 
 It also does not reduce the complexity of compiling
 strings to various target languages that do not necessarily use UTF-16.
 
-## Define "valid UTF-16 strings" as a predicate in a shared library
+## Define "valid UTF-16 strings" as a subset type in a shared library
 
 The next cheapest solution would be to define a subset type of `string` that enforces
 correct usage of surrogate characters.
@@ -185,7 +185,10 @@ This also introduces the same proof obligations as the previous solution,
 although here they could be proved by numerous helper methods that operate on the subset type
 in the same shared library.
 
-***TODO***
+This would likely be the best solution if changing the Dafny language itself was not an option.
+The major downside is that built-in sequence operations such as `s[i]` and `s + s'` would still require additional
+effort to achieve verification, or would have to be abandoned entirely in favour of the helper methods
+provided by the shared library.
 
 ## Change the definition of the string type
 
@@ -223,10 +226,10 @@ and even when the `char` type is used it can often be only implicitly referenced
 This alternative does not seem to be worth the implementation cost or additional cognitive load on users,
 especially since it is hard to imagine any codebase needing to use both `char` and `rune` together.
 
-## Disallow compiling s[i] 
+## Disallow compilation of string indexing
 
 Given popular Unicode encodings such as UTF-8 and UTF-16 do not support random access of characters,
-we could decide to forbid random access of string elements (i.e. `s[i]`) in compiled code,
+we could decide to forbid random access of string elements (e.g. `s[i]`) in compiled code,
 instead directing users to fallback to external code for efficient access,
 or to sequential access via the new [ordered quantification features](https://github.com/dafny-lang/rfcs/pull/10) (once they are implemented).
 This would be a much more disruptive breaking change for existing code, however.

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -9,11 +9,10 @@
 The Dafny `string` type is an alias for the type `seq<char>`, and the `char` type is an opaque built-in type
 representing individual characters. `char` values can be converted to and from `int` values (using `as char` and `as int` expressions),
 and an `int` value corresponding to a `char` value is currently required to be a valid UTF-16 code point, i.e. in the range
-`[0, 65536)`. This range includes the so-called "surrogate" characters, i.e. code points in the range `[0xD800, 0xDFFF)`, which must be used in pairs in order to encode some characters in UTF-16, and are not assignable Unicode code points themselves.
+`[0, 65536)`. This range includes the so-called "surrogate" characters, i.e. code points in the range `[0xD800, 0xDFFF]`, which must be used in pairs in order to encode some characters in UTF-16, and are not assignable Unicode code points themselves.
 
-I propose a breaking change in Dafny 4.0 to make `char` instead represent any Unicode character.
-*** TODO ***: You don't mean any currently assigned character, otherwise you break as new characters are added.
-This means that the corresponding `int` value for a `char` must always be a [Unicode scalar value](https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404), meaning any value in the range `[0, 0x10FFFF]` excluding the surrogate characters from `[0xD800, 0xDFFF)`.
+I propose a breaking change in Dafny 4.0, to make `char` represent any Unicode character, independent of the encoding used.
+This means that the corresponding `int` value for a `char` must always be a [Unicode scalar value](https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404), meaning any value in the range `[0, 0x10FFFF]` but excluding the surrogate characters from `[0xD800, 0xDFFF]`.
 
 # Motivation
 [motivation]: #motivation
@@ -23,16 +22,17 @@ The two primary motivations behind this change are correctness and compatibility
 ## Correctness
 
 The current definition of these types means that the Dafny `string` type allows data that is not a valid Unicode string.
-The value `[0xD800 as char]`, for example, does not represent any character and has no valid encoding in UTF-8.
+The value `[0xD800 as char]`, for example, is not a valid Unicode string and has no valid encoding in UTF-8, UTF-16,
+or any other encoding.
 This means that any logic to process strings must manually specify pre-conditions to exclude invalid values, or
-be less precise with its specification. For example, a naive implementation of UTF-8 encoding would have to reject
+be less precise with its specification. For example, an implementation of UTF-8 encoding would have to reject
 invalid inputs in a pre-condition, dynamically fail if given invalid strings, or implement a lossy encoding by
 discarding or replacing invalid characters.
 
 ## Compatibility
 
 The current definitions of `string` and `char` are biased towards using a UTF-16 encoding at runtime.
-This aligns well with some compilation target languages which also use UTF-16, such as Java and C#, 
+This aligns well with some compilation target languages which also use UTF-16, such as Java, C#, and JavaScript, 
 but less well with those that use the more popular UTF-8 encoding, such as Go or Rust.
 Any Dafny code that interfaces with external code will often have to convert between `string` values and
 native representations of strings, and baking in the assumption of UTF-16 imposes a complexity and performance
@@ -41,28 +41,104 @@ penalty for multiple target environments.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-As of Dafny 4.0, the `char` type ...
+As of Dafny 4.0, the default semantics of the `char` type have been changed to represent Unicode scalar values instead of UTF-16 code points.
+This means that surrogate code points, meaning those in the range `[0xD800, 0xDFFF]`, are no longer allowed. This also means
+code points that require more than 16 bits, meaning those in the range `[0x10000, 0x1FFFF]`, are now directly representable
+as `char` values.
 
-TODO: change \uXXXX to allow up to six digits, reject surrogates? Could allow surrogates and have the compiler enforce pairs
+The definition of the `char` type is controlled by a command-line switch called `/unicodeChar`, where `/unicodeChar:0`
+enables the previous semantics and `/unicodeChar:1` enables the new semantics described above.
+The default prior to Dafny 4.0 is `/unicodeChar:0`, but the default as of Dafny 4.0 is `/unicodeChar:1`.
+This change in definition can cause previously verified code to no longer verify,
+since expressions such as `someIntValue as char` or `someCharValue + 'a'` are no longer allowed to result in
+surrogate code points.
+
+A related but largely orthogonal issue has also been addressed.
+Dafny source code files must be encoded in UTF-8,
+but in previous versions of Dafny string literals could only contain printable and white-space ASCII characters,
+due to a limitation of the parser generator the toolchain uses.
+This has been fixed, and both standard form and verbatim form string literals now allow any Unicode characters.
+A second form of escape sequence, `\UXXXXXXXX`, is now provided to support characters outside of the Basic Multilingual Plane
+using their direct Unicode code points instead of using surrogates.
+This change is fully backwards-compatible and not controlled by the `unicodeChar` flag.
 
 The exact representation of strings at runtime, including the particular encoding,
 is an implementation detail of a particular backend, and will often be optimized for the idioms and support
-of the target environment.
+of the target environment. Enabling Unicode characters will change the target language types used to
+represent characters and strings, and hence may cause compilation errors when using additional external
+target language code.
 
-## Migration
-
-Requirements:
-
-* Can we ensure there is always a compile-time error?
+Note also that although the Unicode scalar value concept is more general than UTF-16 code units,
+it still does not always correspond to what humans will perceive as a single atomic characters when rendered;
+see the concept of grapheme clusters [here](https://unicode.org/reports/tr29/) for more information.
+The proposed change to the `char` type is only intended to allow the Dafny language to safely abstract
+away from encodings, especially to support verifiably-correct code that must compile to multiple target languages.
+Providing more of the concepts defined by the Unicode standard is left out of scope for this proposal,
+under the assumption that it will enable such implementations via Dafny source code in sharable libraries instead.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-(runtime representation compatibility, usually considered advanced use)
+## Verification
 
- In general, each runtime should make it possible to wrap an idiomatic representation of a Unicode string
- as the runtime representation of `seq<char>`. As of the date of writing this, the Java runtime enables this through
- a `StringDafnySequence` class that wraps a `java.lang.String` value.
+The change to the definition of `char` in the `DafnyPrelude.bpl` file is very minimal.
+The only change is to replace expressions such as `0 <= n && n < 65536` with a separate predicate defined as follows:
+
+```boogie
+function char#IsUnicodeScalarValue(n: int): bool {
+  (0                  <= n && n <= 55295   /* 0xD7FF */) || 
+  (57344 /* 0xE000 */ <= n && n <= 1114111 /* 0x10FFFF */ )
+}
+```
+
+As described above in the user-facing description of this feature, this will cause verification failures by design.
+Unlike many other programming languages that have had to add Unicode support over a major version bump,
+Dafny is unusually well-positioned to catch most regressions statically.
+Given this, it is not worth the effort to build any additional migration features to help customers adopt this change.
+
+## Compilation/Runtime
+
+This change also has a reasonably small effect on the runtime behavior of any self-contained Dafny program,
+meaning a program that does not pass data over an interface with external code.
+The only difference is that the `char` type will need to be compiled to a native datatype
+that supports 32 bits of data (or technically 21 according to the actual Unicode scalar value range)
+rather than 16 bits as previous versions did.
+Many target languages will have dedicated types designed to hold any Unicode scalar value,
+such as the `char` primitive type in Rust or the `rune` alias for `int32` in Go.
+
+The main complexity in implementing this change is minimizing the migration pain for
+code bases that use `{:extern}` definitions to pass string values in and out of the Dafny runtime.
+This generally requires converting between the internal representation of Dafny strings
+and the native implementation in the target language,
+e.g. between `Dafny.ISequence<char>` and `System.String` in C#.
+Even there, the various Dafny runtime libraries provide helper methods that can be adjusted 
+to work with the new semantics of Unicode characters.
+In the C# runtime, for example, the `Sequence.FromString(string)` method converts a native string
+to a equivalent `Dafny.ISequence<char>` copy.
+A parallel method named something similar to `Sequence.UnicodeFromString(string)` could be added
+that would return a `Dafny.ISequence<uint32>` copy instead.
+Migrating an existing codebase should reduce to a simple find-and-replace operation.
+
+Each runtime should also make it possible to wrap an idiomatic representation of a Unicode string
+as the runtime representation of the Dafny `seq<char>` type, without having to make an additional copy. 
+At the time of writing this, only the Java runtime supports this feature,
+via a `StringDafnySequence` class that wraps a `java.lang.String` value and implements the `ISequence<Character>` interface.
+Another similar parallel `UnicodeStringDafnySequence` adaptor can be provided that implements `ISequence<Integer>` instead.
+
+The one wrinkle with this feature is that methods such as `select(i)`, which implement Dafny expressions such as `s[i]`,
+currently take constant time on an `StringDafnySequence`, since a `java.lang.String` also stores its contents as UTF-16
+code units. However, if `UnicodeStringDafnySequence.select(i)` will need to produce the i'th Unicode scalar value instead,
+this will require decoding all characters up to that index, which will take linear time in general instead.
+The solution will be to lazily decode strings into their UTF-32 encoded equivalent (i.e. sequence of scalar values)
+on the first operation that requires it. This mirrors the optimization of evaluating concatenation of sequences
+lazily in the current C# and Java runtimes, and means that in most code that manipulates individual characters,
+the amortized runtime of indexing operations will still be constant.
+
+Note that this optimization will also help offset the fact that materializing and manipulating individual `char` values
+will in general require twice as much memory after this change.
+The compiler can leverage this support to initially store string literal values as UTF-8 bytes,
+and operations such as concatenation or equality comparisons can be implemented
+without having to decode these bytes into character values.
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -80,12 +156,21 @@ Why should we *not* do this?
 
 ## Distinct "rune" type
 
+We could maintain the current definition of the `char` type, and introduce a new `rune` type to represent Unicode scalar values
+instead ("rune" being the term Go uses for this).
+This would make it more obvious when reading Dafny source code in isolation whether it was using the new definitions of strings.
+There are often few explicit references to individual character values in code that references string values, however,
+and even when the `char` type is used it can often be only implicitly referenced because of type inference.
+
 ## Disallow compiling s[i] 
+
+Given popular Unicode encodings such as UTF-8 and UTF-16 do not support random access of characters,
+we could decide that 
 
 # Prior art
 [prior-art]: #prior-art
 
-
+Unicode has a long and messy history, and the approach to supporting Unicode varies dramatically across different programming languages.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -221,6 +221,12 @@ If anything, the longer we wait to correct this issue,
 the more Dafny code will continue to be written with subtle bugs that verification does not detect,
 or even new compilation targets that introduce them when compiling.
 
+One disadvantage of this strict approach to the definition of `string` is that
+invalid string data according to the Unicode standard, such as some file paths on Windows,
+cannot be directly represented as a Dafny `string`. This means that some low-level
+APIs or more specialized applications will need to resort to using a type such as
+`seq<uint16>` instead.
+
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
@@ -293,7 +299,7 @@ This would make it more obvious when reading Dafny source code in isolation whet
 There are often few explicit references to individual character values in code that references string values, however,
 and even when the `char` type is used it is often only implicitly referenced because of type inference.
 This alternative does not seem to be worth the implementation cost or additional cognitive load on users,
-especially since it is hard to imagine any codebase needing to use both `char` and `rune` together.
+especially since it will be rare for a codebase to use both `char` and `rune` together.
 
 ## Disallow compilation of string indexing
 
@@ -304,7 +310,7 @@ or to sequential access via the new [ordered quantification features](https://gi
 This would be a much more disruptive breaking change for existing code, however.
 String indexing would not be the first instance in Dafny of a simple, mathematical expression
 that supports verification easily but is inefficient at runtime.
-The proposed lazy decoding approach should provide a good balance between the clean expression of concepts
+The proposed optimizations should provide a good balance between the clean expression of concepts
 and efficient, unsurprising runtime behavior.
 
 ## Change `char` to mean an extended grapheme cluster

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -308,21 +308,29 @@ or could in the future:
 The `System.Text.Rune` struct is provided to represent any Unicode scalar value,
 and its API guarantees that invalid values (e.g. surrogates) will be rejected on construction.
 The method `String.EnumerateRunes()` produces the sequence of runes in a string via an `IEnumerator<Rune>`.
+Any invalid UTF-16 sequences are enumerated as the `U+FFFD` "Replacement Character" `Rune` value.
 
 ## Java:
 
 `char` is one of the eight primitive types in Java, and also represents a UTF-16 code unit.
 In recent versions of the Java Runtime Environment, the `java.lang.String` class supports
 encoding its data either in UTF-16 or in Latin-1, where the latter is an optimization for space
-when all characters in the string are supported by this encoding. 
+when all characters in the string are supported by this encoding.
+A `String` value may contain invalid sequences such as unpaired surrogates.
 
 Java does not included a dedicated type for Unicode scalar values
 and instead uses the 32-bit wide `int` primitive type.
+The `CharSequence.codePoints()` method produces an `IntStream` enumerating the UTF-32 code points in a valid String,
+but will enumerate unpaired surrogates directly as zero-extended `int` values.
 
 ## Go:
 
 In Go a string is a read-only slice of bytes, which generally contains UTF-8 encoded bytes
-but may contain arbitrary bytes. The `rune` type is an alias for `int32`.
+but may contain arbitrary bytes: the Go compiler will reject invalid string literals,
+but it is still possible for strings to contain invalid UTF-8 bytes at runtime.
+The `rune` type is an alias for `int32`,
+and the Go compiler does not prevent casting out-of-range values such as `0x11_0000`
+as `rune` values.
 
 ## JavaScript:
 
@@ -332,13 +340,13 @@ There is no distinct type for representing individual characters.
 ## C++:
 
 The `char` type represents bytes, and the `std::string` class from the standard library
-operates on bytes as character, and generally does not produce correct results if used
+operates on bytes as characters, and generally does not produce correct results if used
 together with any encoding other than single-byte encodings such as ASCII.
 C++11 added two new character types, `char16_t` and `char32_t`, 
 and two new corresponding `std::u16string` and `std::u32string` collection classes.
 It also provides three new kinds of string literals,
 `u8"..."`, `u"..."`, and `U"..."`,
-which produce binary values encoded with UTF-8, UTF-16, and UTF-32 respectively.
+which produce `char[N]`, `char16_t[N]`, and `char32_t[N]` values encoded with UTF-8, UTF-16, and UTF-32 respectively.
 
 ## Python:
 

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -10,12 +10,12 @@ The Dafny `string` type is an alias for the type `seq<char>`, and the `char` typ
 representing individual characters. `char` values can be converted to and from `int` values (using `as char` and `as int` expressions),
 and an `int` value corresponding to a `char` value is currently required to be a valid UTF-16 code unit, i.e. in the range
 `[0, 65536)`. This range includes the so-called ["surrogate" code points](https://unicode.org/faq/utf_bom.html#utf16-2),
-i.e. values in the range `[0xD800, 0xDFFF]`,
+i.e. values in the range `[0xD800, 0xE000)`,
 which must be used in pairs in order to encode some characters in UTF-16,
 and are not assignable Unicode code points themselves.
 
 I propose a breaking change in Dafny 4.0, to make `char` represent any Unicode code point, independent of the encoding used.
-This means that the corresponding `int` value for a `char` must always be a [Unicode scalar value](https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404), meaning any value in the range `[0, 0x10FFFF]` but excluding the surrogate code points from `[0xD800, 0xDFFF]`.
+This means that the corresponding `int` value for a `char` must always be a [Unicode scalar value](https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404), meaning any value in the range `[0, 0x11_0000)` but excluding the surrogate code points from `[0xD800, 0xE000)`.
 
 # Motivation
 [motivation]: #motivation
@@ -116,8 +116,8 @@ The only change is to replace expressions such as `0 <= n && n < 65536` with a s
 
 ```boogie
 function char#IsUnicodeScalarValue(n: int): bool {
-  (0                  <= n && n <= 55295   /* 0xD7FF */) || 
-  (57344 /* 0xE000 */ <= n && n <= 1114111 /* 0x10FFFF */ )
+  (0                  <= n && n < 55296   /* 0xD800 */) || 
+  (57344 /* 0xE000 */ <= n && n < 1114112 /* 0x11_0000 */)
 }
 ```
 

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -143,39 +143,74 @@ without having to decode these bytes into character values.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+Changing the behavior of an existing concept in a backwards-incompatible way always carries a high cost,
+and I do not propose it lightly. 
+
+***TODO***
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
+***TODO***
+
 ## Enforce valid UTF-16 strings in the verifier
 
-## Encode valid UTF-16 strings as a library predicates
+***TODO***
 
-## Distinct string type
+## Define "valid UTF-16 strings" as a predicate in a shared library
 
-## Distinct "rune" type
+***TODO***
+
+## Add a new, distinct string type
+
+Since the current definition of `string` as an alias for `seq<char>` 
+***TODO***
+
+## Add a new, distinct "rune" type
 
 We could maintain the current definition of the `char` type, and introduce a new `rune` type to represent Unicode scalar values
-instead ("rune" being the term Go uses for this).
+instead ("rune" being the term both Go and C# use for this).
 This would make it more obvious when reading Dafny source code in isolation whether it was using the new definitions of strings.
 There are often few explicit references to individual character values in code that references string values, however,
 and even when the `char` type is used it can often be only implicitly referenced because of type inference.
+This alternative does not seem to be worth the implementation cost or additional cognitive load on users,
+especially since it is hard to imagine any codebase needing to use both `char` and `rune` together.
 
 ## Disallow compiling s[i] 
 
 Given popular Unicode encodings such as UTF-8 and UTF-16 do not support random access of characters,
-we could decide that 
+we could decide to forbid random access of string elements in compiled code,
+instead directing users to fallback to external code for efficient access,
+or to sequential access via the new [ordered quantification features](https://github.com/dafny-lang/rfcs/pull/10) (once they are implemented).
+This would be a much more disruptive breaking change for existing code, however.
+String indexing would not be the first instance in Dafny of a simple, mathematical expression
+that supports verification easily but is inefficient at runtime.
+The proposed lazy decoding approach should provide a good balance between the clean expression of concepts
+and efficient, unsurprising runtime behavior.
 
 # Prior art
 [prior-art]: #prior-art
 
 Unicode has a long and messy history, and the approach to supporting Unicode varies dramatically across different programming languages.
+Here is the current state of many of the most popular programming languages, especially those that Dafny currently or will likely
+soon support compiling to:
+
+***TODO***
+
+* C#:
+* Java:
+* Go:
+* JavaScript:
+* C/C++:
+* Rust:
+* Swift:
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+***TODO***
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
+***TODO***

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -1,0 +1,96 @@
+- Feature Name: unicode_strings
+- Start Date: 2022-07-06
+- RFC PR: [dafny-lang/rfcs#13](https://github.com/dafny-lang/rfcs/pull/13)
+- Dafny Issue: [dafny-lang/dafny#413](https://github.com/dafny-lang/dafny/issues/413)
+
+# Summary
+[summary]: #summary
+
+The Dafny `string` type is an alias for the type `seq<char>`, and the `char` type is an opaque built-in type
+representing individual characters. `char` values can be converted to and from `int` values (using `as char` and `as int` expressions),
+and an `int` value corresponding to a `char` value is currently required to be a valid UTF-16 code point, i.e. in the range
+`[0, 65536)`. This range includes the so-called "surrogate" characters, i.e. code points in the range `[0xD800, 0xDFFF)`, which must be used in pairs in order to encode some characters in UTF-16, and are not assignable Unicode code points themselves.
+
+I propose a breaking change in Dafny 4.0 to make `char` instead represent any Unicode character.
+*** TODO ***: You don't mean any currently assigned character, otherwise you break as new characters are added.
+This means that the corresponding `int` value for a `char` must always be a [Unicode scalar value](https://www.unicode.org/versions/Unicode14.0.0/ch03.pdf#G7404), meaning any value in the range `[0, 0x10FFFF]` excluding the surrogate characters from `[0xD800, 0xDFFF)`.
+
+# Motivation
+[motivation]: #motivation
+
+The two primary motivations behind this change are correctness and compatibility.
+
+## Correctness
+
+The current definition of these types means that the Dafny `string` type allows data that is not a valid Unicode string.
+The value `[0xD800 as char]`, for example, does not represent any character and has no valid encoding in UTF-8.
+This means that any logic to process strings must manually specify pre-conditions to exclude invalid values, or
+be less precise with its specification. For example, a naive implementation of UTF-8 encoding would have to reject
+invalid inputs in a pre-condition, dynamically fail if given invalid strings, or implement a lossy encoding by
+discarding or replacing invalid characters.
+
+## Compatibility
+
+The current definitions of `string` and `char` are biased towards using a UTF-16 encoding at runtime.
+This aligns well with some compilation target languages which also use UTF-16, such as Java and C#, 
+but less well with those that use the more popular UTF-8 encoding, such as Go or Rust.
+Any Dafny code that interfaces with external code will often have to convert between `string` values and
+native representations of strings, and baking in the assumption of UTF-16 imposes a complexity and performance
+penalty for multiple target environments.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+As of Dafny 4.0, the `char` type ...
+
+TODO: change \uXXXX to allow up to six digits, reject surrogates? Could allow surrogates and have the compiler enforce pairs
+
+The exact representation of strings at runtime, including the particular encoding,
+is an implementation detail of a particular backend, and will often be optimized for the idioms and support
+of the target environment.
+
+## Migration
+
+Requirements:
+
+* Can we ensure there is always a compile-time error?
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+(runtime representation compatibility, usually considered advanced use)
+
+ In general, each runtime should make it possible to wrap an idiomatic representation of a Unicode string
+ as the runtime representation of `seq<char>`. As of the date of writing this, the Java runtime enables this through
+ a `StringDafnySequence` class that wraps a `java.lang.String` value.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Enforce valid UTF-16 strings in the verifier
+
+## Encode valid UTF-16 strings as a library predicates
+
+## Distinct string type
+
+## Distinct "rune" type
+
+## Disallow compiling s[i] 
+
+# Prior art
+[prior-art]: #prior-art
+
+
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+

--- a/0012-unicode-strings.md
+++ b/0012-unicode-strings.md
@@ -94,7 +94,7 @@ var s4 := @"Unicode is just so 😎";  // Escape sequences are not supported in 
 The exact representation of strings at runtime, including the particular encoding,
 is an implementation detail of a particular backend, and will often be optimized for the idioms and support
 of the target environment. Enabling Unicode characters will change the target language types used to
-represent characters and strings, and hence may cause compilation errors when using additional external
+represent characters and strings, and hence may be a breaking change when using additional external
 target language code.
 
 Note also that although the Unicode scalar value concept is more general than UTF-16 code units,
@@ -102,7 +102,7 @@ it still does not always correspond to what humans will perceive as single atomi
 For example, the string `"e\u0301"` contains two Unicode scalar values, but renders as the single character `é`.
 See the concept of grapheme clusters [here](https://unicode.org/reports/tr29/) for more details.
 The proposed change to the `char` type is only intended to allow the Dafny language to safely abstract
-away from encodings, especially to support verifiably-correct code that must compile to multiple target languages.
+away from encodings, especially to support correct code that must compile to multiple target languages.
 Providing more of the concepts defined by the Unicode standard is left out of scope for this proposal,
 under the assumption that it will enable such implementations via Dafny source code in sharable libraries instead.
 
@@ -144,7 +144,7 @@ e.g. between `Dafny.ISequence<char>` and `System.String` in C#.
 Even there, the various Dafny runtime libraries provide helper methods that can be adjusted 
 to work with the new semantics of Unicode characters.
 In the C# runtime, for example, the `Sequence.FromString(string)` method converts a native string
-to a equivalent `Dafny.ISequence<char>` copy.
+to an equivalent `Dafny.ISequence<char>` copy.
 A parallel method named something similar to `Sequence.UnicodeFromString(string)` could be added
 that would return a `Dafny.ISequence<uint32>` copy instead.
 Migrating an existing codebase should reduce to a simple find-and-replace operation.
@@ -236,7 +236,7 @@ that is at least adequate to replace all existing usage of sequence operations.
 These interfaces often become very large to support all common string operations efficiently,
 and would need very careful thought.
 Although unusual, representing strings directly as sequences of abstract characters
-works very well for a verification-focussed language like Dafny,
+works very well for a verification-focused language like Dafny,
 since sequences are already a deep built-in concept in the language semantics.
 
 This new type could alternatively be introduced with a different name, such as `unicode` as in Python 2,


### PR DESCRIPTION
Resolves #12. Resolves https://github.com/dafny-lang/dafny/issues/413.

Tagging those I suspect will be interested: @dafny-lang/dafny-core @mschlaipfer @txiang61 @seanmcl @indolering @alex-chew @seebees 

Revision 2: Besides general clarification, I decided to drop support for the old `\uXXXX` UTF-16 code unit escape sequence with `/unicodeChar:1`, as keeping the support was creating confusion even though it was technically possible.